### PR TITLE
Fix KPI reports page and backend

### DIFF
--- a/worklenz-backend/src/shared/constants.ts
+++ b/worklenz-backend/src/shared/constants.ts
@@ -45,6 +45,10 @@ export const WorklenzColorCodes = [
   "#767676"
 ];
 
+export const REGION = process.env.AWS_REGION || "";
+export const BUCKET = process.env.BUCKET || "";
+export const S3_URL = process.env.S3_URL || "";
+
 export const AvatarNamesMap: { [x: string]: string } = {
   "A": "#154c9b",
   "B": "#3b7ad4",

--- a/worklenz-frontend/src/app/administrator/kpis/kpi-reports/kpi-reports.component.html
+++ b/worklenz-frontend/src/app/administrator/kpis/kpi-reports/kpi-reports.component.html
@@ -12,7 +12,7 @@
     <ng-template #kpiActions>
       <nz-range-picker
         [(ngModel)]="dateRange"
-        (ngModelChange)="loadInitialKpis()"
+        (ngModelChange)="onFiltersChange()"
         nzFormat="yyyy-MM-dd"
         nzPlaceHolder="Select Date Range"
       >
@@ -21,7 +21,7 @@
       <nz-select
         class="w-25"
         [(ngModel)]="selectedMembers"
-        (ngModelChange)="loadInitialKpis()"
+        (ngModelChange)="onFiltersChange()"
         nzMode="multiple"
         nzAllowClear
         nzPlaceHolder="Select Members"
@@ -32,7 +32,7 @@
       <nz-select
         class="w-25"
         [(ngModel)]="selectedProjects"
-        (ngModelChange)="loadInitialKpis()"
+        (ngModelChange)="onFiltersChange()"
         nzMode="multiple"
         nzAllowClear
         nzPlaceHolder="Select Projects"
@@ -43,7 +43,7 @@
       <nz-select
         class="w-25"
         [(ngModel)]="selectedKpis"
-        (ngModelChange)="loadInitialKpis()"
+        (ngModelChange)="onFiltersChange()"
         nzMode="multiple"
         nzAllowClear
         nzPlaceHolder="Select KPIs"
@@ -57,7 +57,7 @@
           nz-input
           placeholder="Search by KPI name or description"
           [(ngModel)]="searchText"
-          (ngModelChange)="searchKpis()"
+          (ngModelChange)="onSearch()"
         />
       </nz-input-group>
     </ng-template>
@@ -68,11 +68,11 @@
     <nz-table
       #table
       nzSize="small"
-      [nzData]="allKpis"
+      [nzData]="kpis"
       [nzFrontPagination]="false"
       [nzLoading]="loading"
       [(nzPageIndex)]="pageIndex"
-      [nzPageSizeOptions]="paginationSizes"
+      [nzPageSizeOptions]="pageSizes"
       [(nzPageSize)]="pageSize"
       [nzTotal]="total"
       [nzShowSizeChanger]="true"

--- a/worklenz-frontend/src/app/administrator/kpis/kpi-reports/kpi-reports.component.ts
+++ b/worklenz-frontend/src/app/administrator/kpis/kpi-reports/kpi-reports.component.ts
@@ -168,6 +168,14 @@ export class KpiReportsComponent implements OnInit, OnDestroy {
         return parseFloat(completion) || 0;
     }
 
+    openKpiDetails(kpi: KpiReport): void {
+        console.log('Opening KPI details for:', kpi);
+    }
+
+    trackBy(_: number, item: KpiReport): string {
+        return item.id;
+    }
+
     private formatDate(date: Date): string {
         const year = date.getFullYear();
         const month = (date.getMonth() + 1).toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
- improve KPI report filtering logic and Excel export on the server
- expose S3 env constants so tests pass
- fix KPI report component and template inconsistencies

## Testing
- `npm test` *(backend)*
- `npm test -- --watch=false` *(frontend, fails: Error: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_688a4c2d79c4832d866a406b3fc9d348